### PR TITLE
Fix :paitn_dot_net:

### DIFF
--- a/v2/emojis/logo.json
+++ b/v2/emojis/logo.json
@@ -7,7 +7,7 @@
     "\uE003": ["notepad"],
 
     "\uE004": ["aseprite", "ase"],
-    "\uE005": ["paitn_dot_net", "pdn"],
+    "\uE005": ["paint_dot_net", "paitn_dot_net", "pdn"],
     "\uE006": ["blockbench"],
     "\uE007": ["steam"],
 


### PR DESCRIPTION
Add :paint_dot_net: to the list of aliases for logos:\uE005. This does not remove :paitn_dot_net: from the alias list.