### PR TITLE
Remove :51:

### DIFF
--- a/v2/emojis/face_misc.json
+++ b/v2/emojis/face_misc.json
@@ -10,7 +10,7 @@
     "\uE006": ["smiling_imp"],
     "\uE007": ["money_machine", "mr_krabs"],
 
-    "\uE008": ["alien", "51"],
+    "\uE008": ["alien"],
     "\uE009": ["swagger", "cowboy"],
     "\uE00A": ["mlg"],
     "\uE00B": ["anime_glasses"],


### PR DESCRIPTION
The `:51:` alias fucks up time measurement too much! It must be stopped.

# Removals
emoji | aliases
:-: | :--
👽 | "alien", ~~"51"~~